### PR TITLE
Adding AnonymousToken.Server implementation to generate tokens

### DIFF
--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/IssueAnonymousToken.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/IssueAnonymousToken.cs
@@ -1,14 +1,25 @@
-﻿using System;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
+﻿
+using AnonymousTokens.Core.Services;
+using AnonymousTokens.Server.Protocol;
+
 using Fhi.Smittestopp.Verification.Domain.Dtos;
 using Fhi.Smittestopp.Verification.Domain.Interfaces;
 using Fhi.Smittestopp.Verification.Domain.Models;
+
 using MediatR;
+
 using Microsoft.Extensions.Options;
+
 using Optional;
+
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Crypto.EC;
+using Org.BouncyCastle.Utilities.Encoders;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
 {
@@ -25,12 +36,24 @@ namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
         {
             private readonly IAnonymousTokenIssueRecordRepository _anonymousTokenIssueRecordRepository;
             private readonly IAnonymousTokensCertLocator _certLocator;
+            private readonly IPublicKeyStore _publicKeyStore;
+            private readonly IPrivateKeyStore _privateKeyStore;
+            private readonly ITokenGenerator _tokenGenerator;
             private readonly AnonymousTokensConfig _config;
 
-            public Handler(IAnonymousTokenIssueRecordRepository anonymousTokenIssueRecordRepository, IAnonymousTokensCertLocator certLocator, IOptions<AnonymousTokensConfig> config)
+            public Handler(
+                IAnonymousTokenIssueRecordRepository anonymousTokenIssueRecordRepository,
+                IAnonymousTokensCertLocator certLocator,
+                IPublicKeyStore publicKeyStore,
+                IPrivateKeyStore privateKeyStore,
+                ITokenGenerator tokenGenerator,
+                IOptions<AnonymousTokensConfig> config)
             {
                 _anonymousTokenIssueRecordRepository = anonymousTokenIssueRecordRepository;
                 _certLocator = certLocator;
+                _publicKeyStore = publicKeyStore;
+                _privateKeyStore = privateKeyStore;
+                _tokenGenerator = tokenGenerator;
                 _config = config.Value;
             }
 
@@ -49,19 +72,27 @@ namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
                     return Option.None<AnonymousTokenResponse, string>("Anonymous token already issued for the provided JWT-token ID.");
                 }
 
-                var tokenCert = await _certLocator.GetCertificateAsync();
-                var tokenResult = CreateAnonymousTokenForRequest(request.RequestData, tokenCert);
+                var tokenResult = await CreateAnonymousTokenForRequestAsync(request.RequestData);
+
                 await _anonymousTokenIssueRecordRepository.SaveNewRecord(new AnonymousTokenIssueRecord(request.JwtTokenId, request.JwtTokenExpiry));
+
                 return tokenResult.Some<AnonymousTokenResponse, string>();
             }
 
-            private AnonymousTokenResponse CreateAnonymousTokenForRequest(AnonymousTokenRequest request, X509Certificate2 x509Certificate2)
+            private async Task<AnonymousTokenResponse> CreateAnonymousTokenForRequestAsync(AnonymousTokenRequest request)
             {
-                // TODO: create anonymous token for request and cert
-                return new AnonymousTokenResponse
-                {
+                var ecParameters = CustomNamedCurves.GetByOid(X9ObjectIdentifiers.Prime256v1);
 
-                };
+                var k = await _privateKeyStore.GetAsync();
+                var K = await _publicKeyStore.GetAsync();
+                var P = ecParameters.Curve.DecodePoint(Hex.Decode(request.PAsHex));
+
+                var token = _tokenGenerator.GenerateToken(k, K.Q, ecParameters, P);
+                var Q = token.Q;
+                var c = token.c;
+                var z = token.z;
+
+                return new AnonymousTokenResponse(Q, c, z);
             }
         }
     }

--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PrivateKeyStore.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PrivateKeyStore.cs
@@ -1,0 +1,28 @@
+﻿using AnonymousTokens.Core.Services;
+
+using Org.BouncyCastle.Math;
+
+using System.Threading.Tasks;
+
+namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
+{
+    public class PrivateKeyStore : IPrivateKeyStore
+    {
+        private readonly IAnonymousTokensCertLocator _certLocator;
+
+        public PrivateKeyStore(IAnonymousTokensCertLocator certLocator)
+        {
+            _certLocator = certLocator;
+        }
+
+        public async Task<BigInteger> GetAsync()
+        {
+            var cert = await _certLocator.GetCertificateAsync();
+
+            // HWM 08.12 
+            // TODO: convert cert to BigInteger
+
+            return null;
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PublicKeyStore.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PublicKeyStore.cs
@@ -1,0 +1,28 @@
+﻿using AnonymousTokens.Core.Services;
+
+using Org.BouncyCastle.Crypto.Parameters;
+
+using System.Threading.Tasks;
+
+namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
+{
+    public class PublicKeyStore : IPublicKeyStore
+    {
+        private readonly IAnonymousTokensCertLocator _certLocator;
+
+        public PublicKeyStore(IAnonymousTokensCertLocator certLocator)
+        {
+            _certLocator = certLocator;
+        }
+
+        public async Task<ECPublicKeyParameters> GetAsync()
+        {
+            var cert = await _certLocator.GetCertificateAsync();
+
+            // HWM 08.12 
+            // TODO: convert cert to ECPublicKeyParameters    
+
+            return null;
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PublicKeyStore.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PublicKeyStore.cs
@@ -1,6 +1,7 @@
 ﻿using AnonymousTokens.Core.Services;
 
 using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
 
 using System.Threading.Tasks;
 
@@ -17,12 +18,10 @@ namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
 
         public async Task<ECPublicKeyParameters> GetAsync()
         {
-            var cert = await _certLocator.GetCertificateAsync();
+            var certificate = await _certLocator.GetCertificateAsync();
 
-            // HWM 08.12 
-            // TODO: convert cert to ECPublicKeyParameters    
-
-            return null;
+            var convertedCertificate = DotNetUtilities.FromX509Certificate(certificate);
+            return (ECPublicKeyParameters)convertedCertificate.GetPublicKey();
         }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/DomainConfigExtensions.cs
+++ b/Fhi.Smittestopp.Verification.Domain/DomainConfigExtensions.cs
@@ -1,9 +1,12 @@
-﻿using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
+﻿using AnonymousTokens.Core.Services;
+using AnonymousTokens.Server.Protocol;
+
+using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
 using Fhi.Smittestopp.Verification.Domain.Factories;
 using Fhi.Smittestopp.Verification.Domain.Interfaces;
 using Fhi.Smittestopp.Verification.Domain.Models;
-using Fhi.Smittestopp.Verification.Domain.Users;
 using Fhi.Smittestopp.Verification.Domain.Verifications;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,7 +23,10 @@ namespace Fhi.Smittestopp.Verification.Domain
                 .AddSingleton<IAnonymousTokensCertLocator, AnonymousTokensCertLocator>()
                 .AddTransient<IVerificationLimit, VerificationLimit>()
                 .Configure<OneWayPseudonymFactory.Config>(config.GetSection("pseudonyms"))
-                .AddTransient<IPseudonymFactory, OneWayPseudonymFactory>(); ;
+                .AddTransient<IPseudonymFactory, OneWayPseudonymFactory>()
+                .AddSingleton<IPrivateKeyStore, PrivateKeyStore>()
+                .AddSingleton<IPublicKeyStore, PublicKeyStore>()
+                .AddSingleton<ITokenGenerator, TokenGenerator>();
         }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenRequest.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenRequest.cs
@@ -2,6 +2,6 @@
 {
     public class AnonymousTokenRequest
     {
-        //TODO: add request data needed to create anonymous tokens
+        public string PAsHex { get; set; }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenResponse.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenResponse.cs
@@ -1,7 +1,22 @@
-﻿namespace Fhi.Smittestopp.Verification.Domain.Dtos
+﻿using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+using Org.BouncyCastle.Utilities.Encoders;
+
+namespace Fhi.Smittestopp.Verification.Domain.Dtos
 {
     public class AnonymousTokenResponse
     {
-        //TODO: add response data for created anonymous token
+        public string QAsHex { get; set; }
+
+        public string ProofCAsHex { get; set; }
+
+        public string ProofZAsHex { get; set; }
+
+        public AnonymousTokenResponse(ECPoint Q, BigInteger proofC, BigInteger proofZ)
+        {
+            QAsHex = Hex.ToHexString(Q.GetEncoded());
+            ProofCAsHex = Hex.ToHexString(proofC.ToByteArray());
+            ProofZAsHex = Hex.ToHexString(proofZ.ToByteArray());
+        }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenResponse.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Dtos/AnonymousTokenResponse.cs
@@ -12,6 +12,11 @@ namespace Fhi.Smittestopp.Verification.Domain.Dtos
 
         public string ProofZAsHex { get; set; }
 
+        public AnonymousTokenResponse()
+        {
+
+        }
+
         public AnonymousTokenResponse(ECPoint Q, BigInteger proofC, BigInteger proofZ)
         {
             QAsHex = Hex.ToHexString(Q.GetEncoded());

--- a/Fhi.Smittestopp.Verification.Domain/Fhi.Smittestopp.Verification.Domain.csproj
+++ b/Fhi.Smittestopp.Verification.Domain/Fhi.Smittestopp.Verification.Domain.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AnonymousTokens.Server" Version="1.3.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.1.9" />

--- a/Fhi.Smittestopp.Verification.Domain/Fhi.Smittestopp.Verification.Domain.csproj
+++ b/Fhi.Smittestopp.Verification.Domain/Fhi.Smittestopp.Verification.Domain.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.9" />
     <PackageReference Include="Optional" Version="4.0.0" />
     <PackageReference Include="Optional.Async" Version="1.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Fhi.Smittestopp.Verification.Server/Fhi.Smittestopp.Verification.Server.csproj
+++ b/Fhi.Smittestopp.Verification.Server/Fhi.Smittestopp.Verification.Server.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="AnonymousTokens.Server" Version="1.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />

--- a/Fhi.Smittestopp.Verification.Server/Startup.cs
+++ b/Fhi.Smittestopp.Verification.Server/Startup.cs
@@ -1,8 +1,5 @@
-﻿using AnonymousTokens.Core.Services;
-using AnonymousTokens.Server.Protocol;
-
+﻿
 using Fhi.Smittestopp.Verification.Domain;
-using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
 using Fhi.Smittestopp.Verification.Domain.Constants;
 using Fhi.Smittestopp.Verification.Domain.Users;
 using Fhi.Smittestopp.Verification.Msis;
@@ -91,9 +88,6 @@ namespace Fhi.Smittestopp.Verification.Server
             services.Configure<InteractionConfig>(Configuration.GetSection("interaction"));
             services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<IExternalService, ExternalService>();
-            services.AddSingleton<IPrivateKeyStore, PrivateKeyStore>();
-            services.AddSingleton<IPublicKeyStore, PublicKeyStore>();
-            services.AddSingleton<ITokenGenerator, TokenGenerator>();
 
             services.AddDomainServices(Configuration.GetSection("common"));
 

--- a/Fhi.Smittestopp.Verification.Server/Startup.cs
+++ b/Fhi.Smittestopp.Verification.Server/Startup.cs
@@ -1,8 +1,8 @@
 ﻿using AnonymousTokens.Core.Services;
-using AnonymousTokens.Core.Services.InMemory;
 using AnonymousTokens.Server.Protocol;
 
 using Fhi.Smittestopp.Verification.Domain;
+using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
 using Fhi.Smittestopp.Verification.Domain.Constants;
 using Fhi.Smittestopp.Verification.Domain.Users;
 using Fhi.Smittestopp.Verification.Msis;
@@ -91,8 +91,8 @@ namespace Fhi.Smittestopp.Verification.Server
             services.Configure<InteractionConfig>(Configuration.GetSection("interaction"));
             services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<IExternalService, ExternalService>();
-            services.AddSingleton<IPrivateKeyStore, InMemoryPrivateKeyStore>(); // TODO: implement a real store
-            services.AddSingleton<IPublicKeyStore, InMemoryPublicKeyStore>(); // TODO: implement a real store
+            services.AddSingleton<IPrivateKeyStore, PrivateKeyStore>();
+            services.AddSingleton<IPublicKeyStore, PublicKeyStore>();
             services.AddSingleton<ITokenGenerator, TokenGenerator>();
 
             services.AddDomainServices(Configuration.GetSection("common"));

--- a/Fhi.Smittestopp.Verification.Server/Startup.cs
+++ b/Fhi.Smittestopp.Verification.Server/Startup.cs
@@ -1,4 +1,8 @@
-﻿using Fhi.Smittestopp.Verification.Domain;
+﻿using AnonymousTokens.Core.Services;
+using AnonymousTokens.Core.Services.InMemory;
+using AnonymousTokens.Server.Protocol;
+
+using Fhi.Smittestopp.Verification.Domain;
 using Fhi.Smittestopp.Verification.Domain.Constants;
 using Fhi.Smittestopp.Verification.Domain.Users;
 using Fhi.Smittestopp.Verification.Msis;
@@ -6,8 +10,11 @@ using Fhi.Smittestopp.Verification.Persistence;
 using Fhi.Smittestopp.Verification.Server.Account;
 using Fhi.Smittestopp.Verification.Server.Authentication;
 using Fhi.Smittestopp.Verification.Server.ExternalController;
+
 using IdentityServer4.EntityFramework.DbContexts;
+
 using MediatR;
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -84,6 +91,9 @@ namespace Fhi.Smittestopp.Verification.Server
             services.Configure<InteractionConfig>(Configuration.GetSection("interaction"));
             services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<IExternalService, ExternalService>();
+            services.AddSingleton<IPrivateKeyStore, InMemoryPrivateKeyStore>(); // TODO: implement a real store
+            services.AddSingleton<IPublicKeyStore, InMemoryPublicKeyStore>(); // TODO: implement a real store
+            services.AddSingleton<ITokenGenerator, TokenGenerator>();
 
             services.AddDomainServices(Configuration.GetSection("common"));
 

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -19,7 +19,7 @@
       "_comment": "empty client to merge with default client from appsettings.json"
     },
     {
-      "clientId": "test-spa-client2",
+      "clientId": "test-spa-client",
       "requireClientSecret": false,
       "requirePkce": true,
       "allowedGrantTypes": [

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "connectionStrings": {
-    "verificationDb": "Server=localhost;Database=Fhi.Smittestopp.Verification.Dev;Trusted_Connection=True"
+    "verificationDb": "Data Source=(LocalDb)\\MSSQLLocalDB;Database=Fhi.Smittestopp.Verification.Dev;Trusted_Connection=True"
   },
   "Logging": {
     "LogLevel": {

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/IssueAnonymousTokenTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/IssueAnonymousTokenTests.cs
@@ -1,20 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using AnonymousTokens.Client.Protocol;
+using AnonymousTokens.Core.Services;
+using AnonymousTokens.Core.Services.InMemory;
+using AnonymousTokens.Server.Protocol;
+
 using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
 using Fhi.Smittestopp.Verification.Domain.Dtos;
 using Fhi.Smittestopp.Verification.Domain.Interfaces;
 using Fhi.Smittestopp.Verification.Domain.Models;
+
 using FluentAssertions;
 using FluentAssertions.Execution;
+
 using Microsoft.Extensions.Options;
+
 using Moq;
 using Moq.AutoMock;
+
 using NUnit.Framework;
+
 using Optional.Unsafe;
+
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Crypto.EC;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+using Org.BouncyCastle.Utilities.Encoders;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
 {
@@ -108,19 +125,44 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
                 .Returns<string>(x => Task.FromResult(Enumerable.Empty<AnonymousTokenIssueRecord>()));
 
             automocker
-                .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
-                .ReturnsAsync(new X509Certificate2()); // TODO: replace with certificate expected in test
+                .Setup<IPrivateKeyStore, Task<BigInteger>>(x => x.GetAsync()).Returns(new InMemoryPrivateKeyStore().GetAsync());
+
+            automocker
+                .Setup<IPublicKeyStore, Task<ECPublicKeyParameters>>(x => x.GetAsync()).Returns(new InMemoryPublicKeyStore().GetAsync());
+
+            // Initiate AnonymousTokens protocol
+            var initiator = new Initiator();
+            var tokenGenerator = new TokenGenerator();
+            var tokenVerifier = new TokenVerifier(new InMemorySeedStore());
+
+            var ecParameters = CustomNamedCurves.GetByOid(X9ObjectIdentifiers.Prime256v1);
+            var publicKeyStore = new InMemoryPublicKeyStore();
+            var publicKey = publicKeyStore.GetAsync().GetAwaiter().GetResult();
+
+            var privateKeyStore = new InMemoryPrivateKeyStore();
+            var privateKey = privateKeyStore.GetAsync().GetAwaiter().GetResult();
+
+            var init = initiator.Initiate(ecParameters.Curve);
+            var t = init.t;
+            var r = init.r;
+            var P = init.P;
+
+            var (Q, proofC, proofZ) = tokenGenerator.GenerateToken(privateKey, publicKey.Q, ecParameters, P);
+
+            automocker
+                .Setup<ITokenGenerator, (ECPoint Q, BigInteger c, BigInteger z)>(x => x.GenerateToken(privateKey, publicKey.Q, ecParameters, P))
+                .Returns((Q, proofC, proofZ));
 
             var target = automocker.CreateInstance<IssueAnonymousToken.Handler>();
 
-            //Act
+            //Act           
             var result = await target.Handle(new IssueAnonymousToken.Command
             {
                 JwtTokenId = "token-a",
                 JwtTokenExpiry = DateTime.Now.AddMinutes(10),
                 RequestData = new AnonymousTokenRequest
                 {
-                    // TODO: add properties needed in the request
+                    PAsHex = Hex.ToHexString(P.GetEncoded())
                 }
             }, new CancellationToken());
 
@@ -130,9 +172,16 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
                 result.HasValue.Should().BeTrue();
                 var anonymousTokenReponse = result.ValueOrFailure();
 
-                // TODO: add proper checks
                 anonymousTokenReponse.Should().NotBeNull();
+
+                anonymousTokenReponse.QAsHex.Should().Be(Hex.ToHexString(Q.GetEncoded()));
+                anonymousTokenReponse.ProofCAsHex.Should().Be(Hex.ToHexString(proofC.ToByteArray()));
+                anonymousTokenReponse.ProofZAsHex.Should().Be(Hex.ToHexString(proofZ.ToByteArray()));
             }
+
+            var W = initiator.RandomiseToken(ecParameters, publicKey, P, Q, proofC, proofZ, r);
+            var isVerified = await tokenVerifier.VerifyTokenAsync(privateKey, ecParameters.Curve, t, W);
+            isVerified.Should().BeTrue();
         }
     }
 }

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
@@ -1,0 +1,40 @@
+﻿using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
+using Fhi.Smittestopp.Verification.Tests.TestUtils;
+
+using FluentAssertions;
+
+using Moq;
+using Moq.AutoMock;
+
+using NUnit.Framework;
+
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
+{
+    [TestFixture]
+    public class PrivateKeyStoreTests
+    {
+        [Test]
+        public async Task GetAsync_GivenACertificate_ReturnsExpectedPrivateKey()
+        {
+            //Arrange
+            var automocker = new AutoMocker();
+
+            var testCertificate = CertUtils.GenerateTestCert();
+
+            automocker
+                .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
+                .ReturnsAsync(testCertificate);
+
+            var target = automocker.CreateInstance<PrivateKeyStore>();
+
+            //Act
+            var result = await target.GetAsync();
+
+            //Assert
+            result.Should().NotBeNull();
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
+using Fhi.Smittestopp.Verification.Server.Credentials;
 using Fhi.Smittestopp.Verification.Tests.TestUtils;
 
 using FluentAssertions;
@@ -17,7 +18,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
     public class PrivateKeyStoreTests
     {
         [Test]
-        public async Task GetAsync_GivenACertificate_ReturnsExpectedPrivateKey()
+        public async Task GetAsync_GivenAnECCertificate_ReturnsExpectedPrivateKey()
         {
             //Arrange
             var automocker = new AutoMocker();
@@ -27,6 +28,32 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
             automocker
                 .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
                 .ReturnsAsync(testCertificate);
+
+            var target = automocker.CreateInstance<PrivateKeyStore>();
+
+            //Act
+            var result = await target.GetAsync();
+
+            //Assert
+            result.Should().NotBeNull();
+        }
+
+        /// <summary>
+        /// Recommend following this guide for creating the certificate and importing the PFX-file to local machine certificate store: https://gist.github.com/marta-krzyk-dev/83168c9a8e985e5b3b1b14a98b533b9c
+        /// </summary>
+        [Ignore("Requires a certificate installed on local machine")]
+        [Test]
+        public async Task GetAsync_GivenAnECCertificateFromLocalMachine_ReturnsExpectedPrivateKey()
+        {
+            //Arrange
+            var automocker = new AutoMocker();
+
+            var certificateLocator = new LocalCertificateLocator();
+            var certificate = certificateLocator.GetCertificate("<insert your certificate's thumbprint here>").ValueOr(() => null);
+
+            automocker
+                .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
+                .ReturnsAsync(certificate);
 
             var target = automocker.CreateInstance<PrivateKeyStore>();
 

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
@@ -49,7 +49,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
             var automocker = new AutoMocker();
 
             var certificateLocator = new LocalCertificateLocator();
-            var certificate = certificateLocator.GetCertificate("015EE60A57D6B8FC81C93A3ACE8540264C2F5221").ValueOr(() => null);
+            var certificate = certificateLocator.GetCertificate("<insert your certificate's thumbprint here>").ValueOr(() => null);
 
             automocker
                 .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
+using Fhi.Smittestopp.Verification.Server.Credentials;
 using Fhi.Smittestopp.Verification.Tests.TestUtils;
 
 using FluentAssertions;
@@ -17,7 +18,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
     public class PublicKeyStoreTests
     {
         [Test]
-        public async Task GetAsync_GivenACertificate_ReturnsExpectedPrivateKey()
+        public async Task GetAsync_GivenAnECCertificate_ReturnsExpectedPublicKey()
         {
             //Arrange
             var automocker = new AutoMocker();
@@ -27,6 +28,32 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
             automocker
                 .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
                 .ReturnsAsync(testCertificate);
+
+            var target = automocker.CreateInstance<PublicKeyStore>();
+
+            //Act
+            var result = await target.GetAsync();
+
+            //Assert
+            result.Should().NotBeNull();
+        }
+
+        /// <summary>
+        /// Recommend following this guide for creating the certificate and importing the PFX-file to local machine certificate store: https://gist.github.com/marta-krzyk-dev/83168c9a8e985e5b3b1b14a98b533b9c
+        /// </summary>
+        [Ignore("Requires a certificate installed on local machine")]
+        [Test]
+        public async Task GetAsync_GivenAnECCertificateFromLocalMachine_ReturnsExpectedPublicKey()
+        {
+            //Arrange
+            var automocker = new AutoMocker();
+
+            var certificateLocator = new LocalCertificateLocator();
+            var certificate = certificateLocator.GetCertificate("015EE60A57D6B8FC81C93A3ACE8540264C2F5221").ValueOr(() => null);
+
+            automocker
+                .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
+                .ReturnsAsync(certificate);
 
             var target = automocker.CreateInstance<PublicKeyStore>();
 

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PublicKeyStoreTests.cs
@@ -1,0 +1,40 @@
+﻿using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
+using Fhi.Smittestopp.Verification.Tests.TestUtils;
+
+using FluentAssertions;
+
+using Moq;
+using Moq.AutoMock;
+
+using NUnit.Framework;
+
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
+{
+    [TestFixture]
+    public class PublicKeyStoreTests
+    {
+        [Test]
+        public async Task GetAsync_GivenACertificate_ReturnsExpectedPrivateKey()
+        {
+            //Arrange
+            var automocker = new AutoMocker();
+
+            var testCertificate = CertUtils.GenerateTestCert();
+
+            automocker
+                .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
+                .ReturnsAsync(testCertificate);
+
+            var target = automocker.CreateInstance<PublicKeyStore>();
+
+            //Act
+            var result = await target.GetAsync();
+
+            //Assert
+            result.Should().NotBeNull();
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Tests/Fhi.Smittestopp.Verification.Tests.csproj
+++ b/Fhi.Smittestopp.Verification.Tests/Fhi.Smittestopp.Verification.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AnonymousTokens.Client" Version="1.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="Moq.AutoMock" Version="2.1.0" />


### PR DESCRIPTION
Implements 
* `PublicKeyStore` and `PrivateKeyStore` (assumption of how certificates are created for external environments)
* Registers types
* Updated test to demonstrate expected request & response when a new token is requested (performs the whole AnonymousTokens-protocol)
* Handle request to `/api/anonymoustokens` to generate a new token and return values to App/Client.

Tested by using sample-project in https://github.com/HenrikWM/anonymous-tokens/tree/test-client-for-smittestopp2 and point to Verification running on localhost.

@sindremb could you run the unit tests on my branch on your computer so that we get a confirmation about the certificate you have works? We've tested using the CertUtils and the self-signed certificate, so curious if the real FHI-created certificates are also parsable by the key stores.

Any tests we're missing or something else we should cover here on this branch? OK from my and as-is.