### PR TITLE
Add support for PFX-certificate in PrivateKeyStore

### DIFF
--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/AnonymousTokensConfig.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/AnonymousTokensConfig.cs
@@ -4,5 +4,6 @@
     {
         public bool Enabled { get; set; }
         public string CertId { get; set; }
+        public string CertPassword { get; set; }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PrivateKeyStore.cs
+++ b/Fhi.Smittestopp.Verification.Domain/AnonymousTokens/PrivateKeyStore.cs
@@ -1,8 +1,13 @@
 ﻿using AnonymousTokens.Core.Services;
 
+using Microsoft.Extensions.Options;
+
+using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Pkcs;
 
 using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -11,26 +16,35 @@ namespace Fhi.Smittestopp.Verification.Domain.AnonymousTokens
     public class PrivateKeyStore : IPrivateKeyStore
     {
         private readonly IAnonymousTokensCertLocator _certLocator;
+        private readonly string _password;
 
-        public PrivateKeyStore(IAnonymousTokensCertLocator certLocator)
+        public PrivateKeyStore(IOptions<AnonymousTokensConfig> config, IAnonymousTokensCertLocator certLocator)
         {
             _certLocator = certLocator;
+
+            _password = string.IsNullOrEmpty(config.Value.CertPassword) ? string.Empty : config.Value.CertPassword;
         }
 
         public async Task<BigInteger> GetAsync()
         {
             var certificate = await _certLocator.GetCertificateAsync();
 
-            if (certificate.HasPrivateKey)
+            byte[] rawdata = certificate.Export(X509ContentType.Pfx);
+            using (var memStream = new MemoryStream(rawdata))
             {
-                var privateKey = certificate.GetECDsaPrivateKey() ??
-                                 throw new Exception($"Provided certificate ({certificate.Thumbprint}) does not have an ECDsa private key.");
-                var privateKeyParameters = privateKey.ExportParameters(true);
+                var pkcs12Store = new Pkcs12Store(memStream, _password.ToCharArray());
+                foreach (var alias in pkcs12Store.Aliases)
+                {
+                    if (pkcs12Store.IsKeyEntry((string)alias))
+                    {
+                        var privateKeyParameters = (ECPrivateKeyParameters)pkcs12Store.GetKey(alias.ToString()).Key;
 
-                return new BigInteger(privateKeyParameters.D);
+                        return privateKeyParameters.D;
+                    }
+                }
+
+                throw new Exception("Failed to load private key. Certificate " + certificate.Thumbprint + " did not contain a private key");
             }
-
-            throw new Exception("Failed to load private key. Certificate " + certificate.Thumbprint + " did not contain a private key");
         }
     }
 }

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -72,7 +72,8 @@
     },
     "anonymousTokens": {
       "enabled": true,
-      "certId": "F9656C4BFC04586DC844D423148F655088168109"
+      "certId": "F9656C4BFC04586DC844D423148F655088168109",
+      "certPassword": ""
     }
   },
   "cleanupTask": {

--- a/Fhi.Smittestopp.Verification.Server/appsettings.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.json
@@ -82,7 +82,8 @@
     },
     "anonymousTokens": {
       "enabled": false,
-      "certId": "<Inject or override in appsettings.<env>.json name of anonymous token signing cert in key vault per env for release (if certificates.locator=local: use thumbprint)>"
+      "certId": "<Inject or override in appsettings.<env>.json name of anonymous token signing cert in key vault per env for release (if certificates.locator=local: use thumbprint)>",
+      "certPassword": "<Inject or override in appsettings.<env>.json the password used to export the private key from the PFX-certificate file (use empty string if no password is used)"
     }
   },
   "cleanupTask": {

--- a/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/AnonymousTokens/PrivateKeyStoreTests.cs
@@ -4,6 +4,8 @@ using Fhi.Smittestopp.Verification.Tests.TestUtils;
 
 using FluentAssertions;
 
+using Microsoft.Extensions.Options;
+
 using Moq;
 using Moq.AutoMock;
 
@@ -24,6 +26,10 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
             var automocker = new AutoMocker();
 
             var testCertificate = CertUtils.GenerateTestCert();
+
+            automocker
+                .Setup<IOptions<AnonymousTokensConfig>, AnonymousTokensConfig>(x => x.Value)
+                .Returns(new AnonymousTokensConfig());
 
             automocker
                 .Setup<IAnonymousTokensCertLocator, Task<X509Certificate2>>(x => x.GetCertificateAsync())
@@ -47,6 +53,10 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.AnonymousTokens
         {
             //Arrange
             var automocker = new AutoMocker();
+
+            automocker
+                .Setup<IOptions<AnonymousTokensConfig>, AnonymousTokensConfig>(x => x.Value)
+                .Returns(new AnonymousTokensConfig());
 
             var certificateLocator = new LocalCertificateLocator();
             var certificate = certificateLocator.GetCertificate("<insert your certificate's thumbprint here>").ValueOr(() => null);


### PR DESCRIPTION
`PrivateKeyStore` now supports a PFX-certificate with an optional password in order to extract the private key used in Anonymous tokens protocol.