### PR TITLE
(Temporary) Use InMemory stores for anonymous tokens to support current stage on App

### DIFF
--- a/Fhi.Smittestopp.Verification.Domain/DomainConfigExtensions.cs
+++ b/Fhi.Smittestopp.Verification.Domain/DomainConfigExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using AnonymousTokens.Core.Services;
+using AnonymousTokens.Core.Services.InMemory;
 using AnonymousTokens.Server.Protocol;
 
 using Fhi.Smittestopp.Verification.Domain.AnonymousTokens;
@@ -24,8 +25,8 @@ namespace Fhi.Smittestopp.Verification.Domain
                 .AddTransient<IVerificationLimit, VerificationLimit>()
                 .Configure<OneWayPseudonymFactory.Config>(config.GetSection("pseudonyms"))
                 .AddTransient<IPseudonymFactory, OneWayPseudonymFactory>()
-                .AddSingleton<IPrivateKeyStore, PrivateKeyStore>()
-                .AddSingleton<IPublicKeyStore, PublicKeyStore>()
+                .AddSingleton<IPrivateKeyStore, InMemoryPrivateKeyStore>()
+                .AddSingleton<IPublicKeyStore, InMemoryPublicKeyStore>()
                 .AddSingleton<ITokenGenerator, TokenGenerator>();
         }
     }

--- a/Fhi.Smittestopp.Verification.Server/Properties/launchSettings.json
+++ b/Fhi.Smittestopp.Verification.Server/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001"
+      "applicationUrl": "http://localhost:5001"
     }
   }
 }

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -45,11 +45,12 @@
     "clientSecret": "<override using user secrets: dotnet user-secrets set idporten:clientSecret <client-secret>>"
   },
   "msis": {
+    "mock":  true,
     "baseUrl": "https://test-gateway-smittestopp-msis.fhi.no/v1/Msis/",
     "certId": "F9656C4BFC04586DC844D423148F655088168109"
   },
   "signingCredentials": {
-    "useDevSigningCredentials": true,
+    "useDevSigningCredentials": false,
     "signing": "F9656C4BFC04586DC844D423148F655088168109",
     "additionalValidation": []
   },
@@ -72,7 +73,7 @@
     },
     "anonymousTokens": {
       "enabled": true,
-      "certId": "F9656C4BFC04586DC844D423148F655088168109"
+      "certId": "BAD0B835F833D84BB021774515A9FD5CF25C44CF"
     }
   },
   "cleanupTask": {

--- a/Fhi.Smittestopp.Verification.Server/runtimeconfig.template.json
+++ b/Fhi.Smittestopp.Verification.Server/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+﻿{
+  "configProperties": {
+    "Microsoft.AspNetCore.SuppressSameSiteNone": "true"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,17 +7,45 @@ To run this application you will need the .NET Core 3.1 SDK. You can launch the 
 
 ### ID-porten
 
-To perform logins through ID-porten (Test environment) you will also need a registered client for ID-porten Ver1 with "https://localhost:5001/signin-oidc" as a valid post login return url, and "https://localhost:5001/signout-callback-oidc" as a post logout return url. You will also need a valid test user to perform a login, ID-porten has a list of available test users [here](https://difi.github.io/felleslosninger/idporten_testbrukere.html)
+To perform logins through ID-porten (Test environment) you will also need a registered client for ID-porten Ver1 with "http://localhost:5001/signin-oidc" as a valid post login return url, and "https://localhost:5001/signout-callback-oidc" as a post logout return url. You will also need a valid test user to perform a login, ID-porten has a list of available test users [here](https://difi.github.io/felleslosninger/idporten_testbrukere.html)
 
 Run the following command from the `Fhi.Smittestopp.Verification.Server` folder to use your own client.
 
-`dotnet user-secrets set "idPorten:clientId" "<your-client-id>"`
-
-`dotnet user-secrets set "idPorten:clientSecret" "<your-client-secret>"`
+1. `dotnet user-secrets set "idPorten:clientId" "<your-client-id>"`
+2. `dotnet user-secrets set "idPorten:clientSecret" "<your-client-secret>"`
 
 ### Database
 
-The default configuration attempts to create a local MSSQL database. Change the connectionstring in appsettings.json or override the config as needed. A connection string value of `in-memory` will use an in-memory database instead of MSSQL.
+The default configuration attempts to create a MSSQL localdb which should work for most users. Change the connectionstring in appsettings.json or override the config if needed. A connection string value of `in-memory` will use an in-memory database instead of MSSQL.
+
+### Certificate
+
+In order to work with the Fhi.Smittestopp.App, you need to configure a local certificate
+
+1. Generate a certificate for Local Computer, e.g. with PowerShell as Administrator: `New-SelfsignedCertificate -KeyExportPolicy Exportable -Subject "CN=SmittestoppIdCert" -KeySpec Signature -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm SHA256 -CertStoreLocation "cert:\LocalMachine\My"`
+2. Copy the fingerprint of the certificate as `signingCredentials.Signing` in `appsettings.Development.json`
+3. Start "Manage Computer Certificates" and find the certificate under Personal\Certificates. Right click > All tasks > Manage Private Keys and add your user to the list of users that can access the certificate
+4. After starting the server, go to http://localhost:5001/.well-known/openid-configuration/jwks and copy the `x5c` value into `OAuthConf.cs` in Fhi.Smittestopp.App as the value of `OAUTH2_VERIFY_TOKEN_PUBLIC_KEY
+
+### Running on http for localhost
+
+Verification Server can run with http or https, but when running in Visual Studio, a self signed certificate will be used. This will be trusted by the app. The following steps must be in place to run on http:
+
+1. ID-porten client must have http://localhost:5001/signin-oidc as a valid redirect uri (http, not https)
+2. launchSettings.json must specificy `"applicationUrl": "http://localhost:5001"`
+3. In runtimeconfig.template.json `"Microsoft.AspNetCore.SuppressSameSiteNone": "true"` must be specified
+
+
+### Debugging with App and Verification server
+
+The app must run on a real device, as Expose Notification framework is not enabled on the Android emulator or iPhone simulator. The app must be attached with debugger and you must have set up `adb` correctly.
+
+1. Connect the phone
+2. Make the phone able to connect to the host computer: In a terminal window, run `adb reverse tcp:5001 tcp:5001`
+3. Make sure the app has the correct value for OAUTH2_VERIFY_TOKEN_PUBLIC_KEY in OAuthConf
+4. Start the app from Visual Studio in the debugger
+5. The app should now be able to authorize with ID-porten when reporting infection. You can debug both the app and the Verification server in Visual Studio
+
 
 ### Test client
 

--- a/test-client/src/environments/environment.ts
+++ b/test-client/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  authIssuer: 'https://localhost:5001',
+  authIssuer: 'http://localhost:5001',
   clientId: 'test-spa-client'
 };
 


### PR DESCRIPTION
This change in necessary for the current code of the corresponding branch in Fhi.Smittestopp.App to work. It will be updated with new keys as soon as we have support for this.

The branch also contains updated instructions in the README.md file.