### PR TITLE
Handling incompatible SameSite=None behaviour

### DIFF
--- a/Fhi.Smittestopp.Verification.Server/Config.cs
+++ b/Fhi.Smittestopp.Verification.Server/Config.cs
@@ -13,6 +13,7 @@ using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.Stores;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -225,7 +226,86 @@ namespace Fhi.Smittestopp.Verification.Server
                     options.Cookie.SameSite = SameSiteMode.Lax;
                 });
             }
+            else
+            {
+                services.ConfigureSameSiteNoneWorkaround();
+            }
             return services;
+        }
+
+        /// <summary>
+        /// Adds handling of the issues regarding SameSite=None described here:
+        /// https://itnext.io/user-agent-sniffing-only-way-to-deal-with-upcoming-samesite-cookie-changes-6f79a18e541
+        /// https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+        /// </summary>
+        /// <param name="services"></param>
+        private static void ConfigureSameSiteNoneWorkaround(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext =>
+                    CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext =>
+                    CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+            });
+        }
+
+        private static void CheckSameSite(HttpContext httpContext, CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None)
+            {
+                var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+                if (DisallowsSameSiteNone(userAgent))
+                {
+                    options.SameSite = SameSiteMode.Unspecified;
+                }
+            }
+        }
+
+        /// <summary>
+        /// This user agent sniffing should cover most browsers handling SameSite=None in an incompatible way
+        /// </summary>
+        /// <param name="userAgent">The user agent string to check SameSite=None behaviour for</param>
+        /// <returns>True if provided userAgent matches known implemenations having an incompatible handling of SameSite=None</returns>
+        private static bool DisallowsSameSiteNone(string userAgent)
+        {
+            if (string.IsNullOrEmpty(userAgent))
+            {
+                return false;
+            }
+
+            // Cover all iOS based browsers here. This includes:
+            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+            // All of which are broken by SameSite=None, because they use the iOS networking stack
+            if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+            {
+                return true;
+            }
+
+            // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+            // - Safari on Mac OS X.
+            // This does not include:
+            // - Chrome on Mac OS X
+            // Because they do not use the Mac OS networking stack.
+            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+            {
+                return true;
+            }
+
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // and none in this range require it.
+            // Note: this covers some pre-Chromium Edge versions, 
+            // but pre-Chromium Edge does not require SameSite=None.
+            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Fhi.Smittestopp.Verification.Server/Startup.cs
+++ b/Fhi.Smittestopp.Verification.Server/Startup.cs
@@ -126,8 +126,9 @@ namespace Fhi.Smittestopp.Verification.Server
             app.UseStaticFiles();
             app.UseRouting();
 
-            app.UseIdentityServer();
+            app.UseCookiePolicy();
 
+            app.UseIdentityServer();
             app.UseAuthentication();
             app.UseAuthorization();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Added user agent sniffing handling incompatible SameSite=None behaviour for most affected browsers based on https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/