### PR TITLE
Enable identity verification without requiring a positive MSIS test result

### DIFF
--- a/Fhi.Smittestopp.Verification.Domain/Constants/IdPortenClaims.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/IdPortenClaims.cs
@@ -1,7 +1,12 @@
 ﻿namespace Fhi.Smittestopp.Verification.Domain.Constants
 {
     /// <summary>
-    /// https://difi.github.io/felleslosninger/oidc_guide_idporten.html
+    /// 
+    /// https://docs.digdir.no/oidc_protocol_id_token.html
+    ///
+    /// “Personidentifikator” - the Norwegian national ID number (fødselsnummer/d-nummer) of the autenticated end user.
+    /// This claim is not included if no_pid scope was requested or pre-registered on the client.
+    /// 
     /// </summary>
     public static class IdPortenClaims
     {

--- a/Fhi.Smittestopp.Verification.Domain/Constants/VerificationClaims.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/VerificationClaims.cs
@@ -4,6 +4,6 @@
     {
         public const string VerifiedPositiveTestDate = "vptd";
         public const string AnonymousToken = "covid19_anonymous_token";
-        public const string DoNotPerformMsisLookup = "no-msis";
+        public const string SkipMsisLookup = "no-msis";
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Constants/VerificationClaims.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/VerificationClaims.cs
@@ -4,5 +4,6 @@
     {
         public const string VerifiedPositiveTestDate = "vptd";
         public const string AnonymousToken = "covid19_anonymous_token";
+        public const string DoNotPerformMsisLookup = "no-msis";
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Constants/VerificationRoles.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/VerificationRoles.cs
@@ -3,5 +3,6 @@
     public static class VerificationRoles
     {
         public const string UploadApproved = "upload-approved";
+        public const string Underaged = "underaged";
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Constants/VerificationScopes.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/VerificationScopes.cs
@@ -3,6 +3,7 @@
     public static class VerificationScopes
     {
         public const string UploadApi = "upload-api";
+        public const string DoNotPerformMsisLookup = "no-msis";
         public const string VerificationInfo = "verification-info";
         /// <summary>
         /// Scope compatible with DK-app Smitte|Stop

--- a/Fhi.Smittestopp.Verification.Domain/Constants/VerificationScopes.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Constants/VerificationScopes.cs
@@ -3,7 +3,7 @@
     public static class VerificationScopes
     {
         public const string UploadApi = "upload-api";
-        public const string DoNotPerformMsisLookup = "no-msis";
+        public const string SkipMsisLookup = "no-msis";
         public const string VerificationInfo = "verification-info";
         /// <summary>
         /// Scope compatible with DK-app Smitte|Stop

--- a/Fhi.Smittestopp.Verification.Domain/Interfaces/IVerificationLimitConfig.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Interfaces/IVerificationLimitConfig.cs
@@ -6,5 +6,6 @@ namespace Fhi.Smittestopp.Verification.Domain.Interfaces
     {
         int MaxVerificationsAllowed { get; }
         TimeSpan MaxLimitDuration { get; }
+        int MinimumAgeInYears { get; }
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Models/VerificationLimit.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Models/VerificationLimit.cs
@@ -27,5 +27,6 @@ namespace Fhi.Smittestopp.Verification.Domain.Models
     {
         public int MaxVerificationsAllowed { get; set; } = 3;
         public TimeSpan MaxLimitDuration { get; set; } = TimeSpan.FromDays(1);
+        public int MinimumAgeInYears { get; set; } = 16;
     }
 }

--- a/Fhi.Smittestopp.Verification.Domain/Utilities/NationalIdentifierValidation.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Utilities/NationalIdentifierValidation.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Globalization;
+
+namespace Fhi.Smittestopp.Verification.Domain.Utilities.NationalIdentifiers
+{
+
+    /// <summary>
+    /// Extention methods for validation of national identifiers (Fødselsnummer and direktoratnummer).
+    /// </summary>
+    public static class NationalIdentifierValidation
+    {
+        /// <summary>
+        ///     Validates a given fødselsnummer.
+        /// </summary>
+        /// <param name="fnr">The fødselsnummer to validate.</param>
+        /// <returns>Whether the fødselsnummer was valid or not.</returns>
+        public static bool IsValidFNummer(this string fnr)
+        {
+            if (string.IsNullOrEmpty(fnr) || fnr.Length != 11 || fnr.Contains(" "))
+            {
+                return false;
+            }
+
+            try
+            {
+                long.Parse(fnr);
+                DateTime.ParseExact(fnr.Substring(0, 6), "ddMMyy", new CultureInfo("nb-NO"));
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            return CheckControlDigits(fnr);
+        }
+
+        /// <summary>
+        ///     Validates a given d-nummer.
+        /// </summary>
+        /// <param name="dnr">D-nummer to validate.</param>
+        /// <returns>Whether the provided d-nummer was valid or not</returns>
+        /// <remarks>
+        ///     Et D-nummer er ellevesifret, som ordinære fødselsnummer, og består av en
+        ///     modifisert sekssifret fødselsdato og et femsifret personnummer.
+        ///     Fødselsdatoen modifiseres ved at det legges til 4 på det første sifferet:
+        ///     en person født 1. januar 1980 får dermed fødselsdato 410180, mens en som er født 31. januar
+        ///     1980 får 710180.
+        /// </remarks>
+        public static bool IsValidDNummer(this string dnr)
+        {
+            if (string.IsNullOrEmpty(dnr) || dnr.Length != 11 || dnr.Contains(" "))
+            {
+                return false;
+            }
+
+            try
+            {
+                long.Parse(dnr);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            var firstDigit = int.Parse(dnr.Substring(0, 1));
+
+            if (firstDigit > 7 || (firstDigit - 4) < 0)
+            {
+                return false;
+            }
+
+            firstDigit = firstDigit - 4;
+            try
+            {
+                DateTime.ParseExact(firstDigit + dnr.Substring(1, 5), "ddMMyy", new CultureInfo("nb-NO"));
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            return CheckControlDigits(dnr);
+        }
+        
+        public static DateTime BirthdateFromDNummer(this string dnr)
+        {
+            var firstDigit = int.Parse(dnr.Substring(0, 1));
+            firstDigit -= 4;
+            return DateTime.ParseExact(firstDigit + dnr.Substring(1, 5), "ddMMyy", new CultureInfo("nb-NO"));
+        }
+        
+        /// <summary>
+        ///     Get the birth date from the given 'Fødselsnummer'
+        /// </summary>
+        /// <returns></returns>
+        public static DateTime BirthDateFromFNummer(this string fnr)
+        {
+            return DateTime.ParseExact(fnr.Substring(0, 6), "ddMMyy", new CultureInfo("nb-NO"));
+        }
+
+        /// <summary>
+        /// Determines if it is possible to determine age of a given number
+        /// </summary>
+        /// <param name="fnrOrDnr"></param>
+        /// <returns></returns>
+        public static bool CanDetermineAge(this string fnrOrDnr)
+        {
+            return !string.IsNullOrEmpty(fnrOrDnr) && (fnrOrDnr.IsValidDNummer() || fnrOrDnr.IsValidFNummer());  
+        } 
+        
+        /// <summary>
+        /// Determine if a person is younger than a given age limit
+        /// </summary>
+        /// <param name="nationalIdentifier"></param>
+        /// <param name="ageLimitInYears"></param>
+        /// <returns></returns>
+        public static bool IsPersonYoungerThanAgeLimit(this string nationalIdentifier, int ageLimitInYears)
+        {
+            if (!nationalIdentifier.CanDetermineAge())
+            {
+                // We cannot determine age, and must assume that the person is younger than age limit 
+                return true;
+            }
+            DateTime birthdate = DateTime.Now.Date;
+            if (nationalIdentifier.IsValidFNummer())
+                birthdate = nationalIdentifier.BirthDateFromFNummer();
+            else if (nationalIdentifier.IsValidDNummer())
+                birthdate = nationalIdentifier.BirthdateFromDNummer();
+            
+            return birthdate.Date >= DateTime.Now.Date.AddYears(-ageLimitInYears);
+        }
+        
+        /// <summary>
+        /// Routine for validating control digits
+        /// https://no.wikipedia.org/wiki/F%C3%B8dselsnummer 
+        /// </summary>
+        /// <param name="fNummerOrDNummer"></param>
+        /// <returns></returns>
+        private static bool CheckControlDigits(string fNummerOrDNummer)
+        {
+            var v1 = new [] { 3, 7, 6, 1, 8, 9, 4, 5, 2 } ;
+            var v2 = new [] { 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 } ;
+
+            var s1 = 0;
+            var s2 = 0;
+
+            for (var i = 0; i < 9; i++)
+            {
+                s1 += Convert.ToInt16(fNummerOrDNummer.Substring(i, 1)) * v1[i];
+            }
+
+            var r1 = s1 % 11;
+            var k1 = 11 - r1;
+
+            if (k1 == 11)
+            {
+                k1 = 0;
+            }
+            else if (k1 == 10)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < 10; i++)
+            {
+                s2 += Convert.ToInt16(fNummerOrDNummer.Substring(i, 1)) * v2[i];
+            }
+
+            var r2 = s2 % 11;
+            var k2 = 11 - r2;
+
+            if (k2 == 11)
+            {
+                k2 = 0;
+            }
+            else if (k2 == 10)
+            {
+                return false;
+            }
+
+            if ((Convert.ToInt16(fNummerOrDNummer.Substring(9, 1)) == k1 && Convert.ToInt16(fNummerOrDNummer.Substring(10, 1)) == k2))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Domain/Verifications/VerifyIdentifiedUser.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Verifications/VerifyIdentifiedUser.cs
@@ -86,7 +86,7 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
             /// <summary>
             /// Medified version of CreateRealVerificationResult where behaviour can be overridden based on configuration
             /// </summary>
-            private async Task<VerificationResult> CreateTestCaseVerificationResult(string nationalIdentifier, string pseudonym, bool userHasRequestedToSkipMsisLookup)
+            private async Task<VerificationResult> CreateTestCaseVerificationResult(string nationalIdentifier, string pseudonym, bool skipMsisLookup)
             {
                 if (_config.TestCases.TechnicalErrorUsers.Contains(nationalIdentifier))
                 {
@@ -97,7 +97,7 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
                     ? Enumerable.Empty<VerificationRecord>()
                     : await _verificationRecordsRepository.RetrieveRecordsForPseudonym(pseudonym, _verificationLimit.RecordsCutoff);
                 
-                if (userHasRequestedToSkipMsisLookup)
+                if (skipMsisLookup)
                 {
                     return await CreateNoMsisVerificationResult(pseudonym, existingRecords);
                 }
@@ -135,7 +135,7 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
             private async Task<VerificationResult> CreateNoMsisVerificationResult(string pseudonym, IEnumerable<VerificationRecord> existingRecords)
             {
                 _logger.LogDebug("Creating result for identified user where user requested to skip the MSIS lookup");
-                var verificationResult = new VerificationResult(existingRecords, _verificationLimit, true);
+                var verificationResult = new VerificationResult(existingRecords, _verificationLimit, skipMsisLookup: true);
 
                 await SaveNewRecordIfWithinVerificationLimit(pseudonym, verificationResult);
                 return verificationResult;
@@ -144,7 +144,7 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
             private async Task<VerificationResult> CreateNonPositiveResult(string pseudonym, IEnumerable<VerificationRecord> existingRecords)
             {
                 _logger.LogDebug("Creating non-positive verification result for identified user");
-                var verificationResult = new VerificationResult(existingRecords, _verificationLimit, false);
+                var verificationResult = new VerificationResult(existingRecords, _verificationLimit, skipMsisLookup: false);
                 await SaveNewRecordIfWithinVerificationLimit(pseudonym, verificationResult);
 
                 return verificationResult;

--- a/Fhi.Smittestopp.Verification.Domain/Verifications/VerifyPinUser.cs
+++ b/Fhi.Smittestopp.Verification.Domain/Verifications/VerifyPinUser.cs
@@ -13,10 +13,14 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
         public class Command : IRequest<VerificationResult>
         {
             public string Pseudonym { get; set; }
+            public bool IsPinVerified { get; set; }
+            public bool SkipMsisLookup { get; set; }
 
-            public Command(string pseudonym)
+            public Command(string pseudonym, bool isPinVerified, bool skipMsisLookup)
             {
                 Pseudonym = pseudonym;
+                IsPinVerified = isPinVerified;
+                SkipMsisLookup = skipMsisLookup;
             }
         }
 
@@ -41,8 +45,10 @@ namespace Fhi.Smittestopp.Verification.Domain.Verifications
 
                 var verificationRecords = existingRecords.Concat(new[] { newRecord });
 
-                _logger.LogInformation("Creating verified positive result for pin user");
-                var verificationResult = new VerificationResult(new PositiveTestResult(), verificationRecords, _verificationLimit);
+                _logger.LogInformation("Creating verification result for pin user");
+                var verificationResult = request.IsPinVerified 
+                    ? new VerificationResult(new PositiveTestResult() , verificationRecords, _verificationLimit)
+                    : new VerificationResult(verificationRecords, _verificationLimit, request.SkipMsisLookup);
 
                 await _verificationRecordsRepository.SaveNewRecord(newRecord);
 

--- a/Fhi.Smittestopp.Verification.Server/Account/ProfileService.cs
+++ b/Fhi.Smittestopp.Verification.Server/Account/ProfileService.cs
@@ -9,6 +9,7 @@ using Fhi.Smittestopp.Verification.Domain.Interfaces;
 using Fhi.Smittestopp.Verification.Domain.Models;
 using Fhi.Smittestopp.Verification.Domain.Utilities.NationalIdentifiers;
 using Fhi.Smittestopp.Verification.Domain.Verifications;
+using IdentityModel;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
 using IdentityServer4.Validation;
@@ -56,8 +57,8 @@ namespace Fhi.Smittestopp.Verification.Server.Account
             var nationalIdentifier = subject?.Claims?.FirstOrDefault(c => c.Type == InternalClaims.NationalIdentifier)?.Value;
             if (!nationalIdentifier.CanDetermineAge() || nationalIdentifier.IsPersonYoungerThanAgeLimit(_verificationLimitConfig.MinimumAgeInYears))
             {
-                // Return only blocking claims: Too young or can't determine age
-                return GetClaimsForBlockedPerson();
+                // Return only underaged claims: Too young or can't determine age
+                return GetClaimsForUnderagedPerson();
             }
 
             try
@@ -102,7 +103,7 @@ namespace Fhi.Smittestopp.Verification.Server.Account
                 return new []{new Claim(DkSmittestopClaims.Covid19Status, DkSmittestopClaims.StatusValues.Unknwon)};
             }
         }
-        private IEnumerable<Claim> GetClaimsForBlockedPerson()
+        private IEnumerable<Claim> GetClaimsForUnderagedPerson()
         {
             var customClaims = new List<Claim>();
             customClaims.AddRange(new[]
@@ -110,6 +111,7 @@ namespace Fhi.Smittestopp.Verification.Server.Account
                 new Claim(DkSmittestopClaims.Covid19Blocked, "true"),
                 new Claim(DkSmittestopClaims.Covid19LimitCount, _verificationLimitConfig.MaxVerificationsAllowed.ToString()),
                 new Claim(DkSmittestopClaims.Covid19LimitDuration, _verificationLimitConfig.MaxLimitDuration.TotalHours.ToString()),
+                new Claim(JwtClaimTypes.Role, VerificationRoles.Underaged),
             });
             return customClaims;
         }

--- a/Fhi.Smittestopp.Verification.Server/Config.cs
+++ b/Fhi.Smittestopp.Verification.Server/Config.cs
@@ -72,11 +72,11 @@ namespace Fhi.Smittestopp.Verification.Server
                         JwtClaimTypes.Role
                     }
                 },
-                new ApiScope(VerificationScopes.DoNotPerformMsisLookup, "Do not perform MSIS lookup")
+                new ApiScope(VerificationScopes.SkipMsisLookup, "Skip (do not perform) MSIS lookup")
                 {
                     UserClaims = new []
                     {
-                        VerificationClaims.DoNotPerformMsisLookup
+                        VerificationClaims.SkipMsisLookup
                     }
                 },
                 new ApiScope(VerificationScopes.DkSmittestop, "Diagnosis keys upload API")

--- a/Fhi.Smittestopp.Verification.Server/Config.cs
+++ b/Fhi.Smittestopp.Verification.Server/Config.cs
@@ -1,4 +1,5 @@
-﻿using IdentityServer4.Models;
+﻿using System;
+using IdentityServer4.Models;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -69,6 +70,13 @@ namespace Fhi.Smittestopp.Verification.Server
                     UserClaims = new []
                     {
                         JwtClaimTypes.Role
+                    }
+                },
+                new ApiScope(VerificationScopes.DoNotPerformMsisLookup, "Do not perform MSIS lookup")
+                {
+                    UserClaims = new []
+                    {
+                        VerificationClaims.DoNotPerformMsisLookup
                     }
                 },
                 new ApiScope(VerificationScopes.DkSmittestop, "Diagnosis keys upload API")

--- a/Fhi.Smittestopp.Verification.Server/appsettings.AzDev.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.AzDev.json
@@ -30,7 +30,8 @@
         "openid",
         "verification-info",
         "upload-api",
-        "smittestop"
+        "smittestop",
+        "no-msis"
       ],
       "redirectUris": [
         "http://localhost:4200/"

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -74,7 +74,7 @@
     },
     "anonymousTokens": {
       "enabled": true,
-      "masterKeyCertId": "1b5e4586cd81ca05e21b60e3cdec0fc4b3eaf7fa"
+      "masterKeyCertId": "F9656C4BFC04586DC844D423148F655088168109"
     }
   },
   "cleanupTask": {

--- a/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.Development.json
@@ -29,7 +29,8 @@
         "openid",
         "verification-info",
         "upload-api",
-        "smittestop"
+        "smittestop",
+        "no-msis"
       ],
       "redirectUris": [
         "http://localhost:4200/"
@@ -73,7 +74,7 @@
     },
     "anonymousTokens": {
       "enabled": true,
-      "masterKeyCertId": "F9656C4BFC04586DC844D423148F655088168109"
+      "masterKeyCertId": "1b5e4586cd81ca05e21b60e3cdec0fc4b3eaf7fa"
     }
   },
   "cleanupTask": {

--- a/Fhi.Smittestopp.Verification.Server/appsettings.NhnQa.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.NhnQa.json
@@ -29,7 +29,8 @@
         "openid",
         "verification-info",
         "upload-api",
-        "smittestop"
+        "smittestop",
+        "no-msis"
       ],
       "redirectUris": [
         "http://localhost:4200/"

--- a/Fhi.Smittestopp.Verification.Server/appsettings.NhnTest.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.NhnTest.json
@@ -29,7 +29,8 @@
         "openid",
         "verification-info",
         "upload-api",
-        "smittestop"
+        "smittestop",
+        "no-msis"
       ],
       "redirectUris": [
         "http://localhost:4200/"

--- a/Fhi.Smittestopp.Verification.Server/appsettings.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.json
@@ -66,7 +66,8 @@
   "common": {
     "verificationLimit": {
       "MaxVerificationsAllowed": 3,
-      "MaxLimitDuration": "1.00:00:00.0"
+      "MaxLimitDuration": "1.00:00:00.0",
+      "MinimumAgeInYears": 16
     },
     "pseudonyms": {
       "key": "<Inject base64 representation of key used for hashing ID-porten pseudonyms>"

--- a/Fhi.Smittestopp.Verification.Server/appsettings.json
+++ b/Fhi.Smittestopp.Verification.Server/appsettings.json
@@ -28,7 +28,8 @@
         "openid",
         "verification-info",
         "upload-api",
-        "smittestop"
+        "smittestop",
+        "no-msis"
       ],
       "redirectUris": [
         "no.fhi.smittestopp-exposure-notification:/oauth2redirect"

--- a/Fhi.Smittestopp.Verification.Tests/Domain/Utilities/NationalIdentifierValidationTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/Utilities/NationalIdentifierValidationTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Fhi.Smittestopp.Verification.Domain.Utilities.NationalIdentifiers;
+using NUnit.Framework;
+
+namespace Fhi.Smittestopp.Verification.Tests.Domain.Utilities
+{
+    [TestFixture]
+    public class NationalIdentifierValidationTests
+    {
+        const string ValidFNummerBorn1994 = "08089409382";
+        const string ValidDnummerBorn1989 = "44098923540";
+        const string ValidFNummerBorn2020 = "01012068359";
+        
+        [TestCase(ValidFNummerBorn1994,ExpectedResult = true)]
+        [TestCase(ValidDnummerBorn1989,ExpectedResult = false)]
+        [TestCase(null,ExpectedResult = false)]
+        public bool IsValidFnummer(string fnummer)
+        {
+            return fnummer.IsValidFNummer();
+        }
+        
+        [TestCase(ValidDnummerBorn1989,ExpectedResult = true)]
+        [TestCase(ValidFNummerBorn1994,ExpectedResult = false)]
+        [TestCase(null,ExpectedResult = false)]
+        [TestCase("",ExpectedResult = false)]
+        [TestCase("1234",ExpectedResult = false)]
+        public bool IsValidDnummer(string dnummer)
+        {
+            return dnummer.IsValidDNummer();
+        }
+        
+        [TestCase(ValidFNummerBorn1994,ExpectedResult = true)]
+        [TestCase(ValidDnummerBorn1989,ExpectedResult = true)]
+        [TestCase("nan",ExpectedResult = false)]
+        [TestCase(null,ExpectedResult = false)]
+        [TestCase("08089412345",ExpectedResult = false)]
+        public bool CanDetermineAge(string fOrDnummer)
+        {
+            return fOrDnummer.CanDetermineAge();
+        }
+
+        [TestCase(ValidFNummerBorn1994,16,ExpectedResult = false)]
+        [TestCase(ValidDnummerBorn1989,16,ExpectedResult = false)]
+        [TestCase(ValidDnummerBorn1989,16,ExpectedResult = false)]
+        [TestCase(ValidFNummerBorn2020, 16, ExpectedResult = true)]
+        [TestCase(ValidFNummerBorn1994,100,ExpectedResult = true)]
+        [TestCase(null,16,ExpectedResult = true)]
+        public bool IsPersonYoungerThanAgeLimit(string nationalIdentifier, int ageLimit)
+        {
+            return nationalIdentifier.IsPersonYoungerThanAgeLimit(ageLimit);
+        }
+    }
+}

--- a/Fhi.Smittestopp.Verification.Tests/Domain/Verifications/VerifyIdentifiedUserTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/Verifications/VerifyIdentifiedUserTests.cs
@@ -35,7 +35,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.Verifications
 
             var target = automocker.CreateInstance<VerifyIdentifiedUser.Handler>();
 
-            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1"), new CancellationToken());
+            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1", false), new CancellationToken());
 
             result.HasVerifiedPostiveTest.Should().BeFalse();
             result.PositiveTestDate.Should().Be(Option.None<DateTime>());
@@ -64,7 +64,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.Verifications
 
             var target = automocker.CreateInstance<VerifyIdentifiedUser.Handler>();
 
-            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1"), new CancellationToken());
+            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1",false), new CancellationToken());
 
             result.HasVerifiedPostiveTest.Should().BeTrue();
             result.PositiveTestDate.Should().Be(DateTime.Today.AddDays(-7).Some());
@@ -102,7 +102,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.Verifications
 
             var target = automocker.CreateInstance<VerifyIdentifiedUser.Handler>();
 
-            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1"), new CancellationToken());
+            var result = await target.Handle(new VerifyIdentifiedUser.Command("01019098765", "pseudo-1",false), new CancellationToken());
 
             result.HasVerifiedPostiveTest.Should().BeTrue();
             result.VerificationLimitExceeded.Should().BeTrue();

--- a/Fhi.Smittestopp.Verification.Tests/Domain/Verifications/VerifyPinUserTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Domain/Verifications/VerifyPinUserTests.cs
@@ -23,7 +23,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.Verifications
             
             var target = automocker.CreateInstance<VerifyPinUser.Handler>();
 
-            var result = await target.Handle(new VerifyPinUser.Command("pseudo-1"), new CancellationToken());
+            var result = await target.Handle(new VerifyPinUser.Command("pseudo-1", true, false), new CancellationToken());
 
             result.HasVerifiedPostiveTest.Should().BeTrue();
             result.PositiveTestDate.Should().Be(Option.None<DateTime>());
@@ -46,7 +46,7 @@ namespace Fhi.Smittestopp.Verification.Tests.Domain.Verifications
 
             var target = automocker.CreateInstance<VerifyPinUser.Handler>();
 
-            var result = await target.Handle(new VerifyPinUser.Command("pseudo-1"), new CancellationToken());
+            var result = await target.Handle(new VerifyPinUser.Command("pseudo-1", true, false), new CancellationToken());
 
             result.HasVerifiedPostiveTest.Should().BeTrue();
             result.VerificationLimitExceeded.Should().BeTrue();

--- a/Fhi.Smittestopp.Verification.Tests/Server/Account/ProfileServiceTests.cs
+++ b/Fhi.Smittestopp.Verification.Tests/Server/Account/ProfileServiceTests.cs
@@ -10,6 +10,7 @@ using Fhi.Smittestopp.Verification.Domain.Verifications;
 using Fhi.Smittestopp.Verification.Server.Account;
 using Fhi.Smittestopp.Verification.Tests.TestUtils;
 using FluentAssertions;
+using IdentityModel;
 using IdentityServer4.Models;
 using MediatR;
 using Moq;
@@ -52,13 +53,14 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
                 .SetupOptions(new AnonymousTokensConfig
                 {
                     Enabled = false
-                });
+                })
+                .SetupOptions(DefaultVerificationLimitConfig);
 
             var context = new ProfileDataRequestContext
             {
                 Subject = new ClaimsPrincipal(new ClaimsIdentity(new []
                 {
-                    new Claim(InternalClaims.NationalIdentifier, "01019098765"),
+                    new Claim(InternalClaims.NationalIdentifier, "08089409382"),
                     new Claim(InternalClaims.Pseudonym, "pseudo-1")
                 })),
                 RequestedClaimTypes = new []{ DkSmittestopClaims.Covid19Status }
@@ -71,23 +73,61 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
             context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19Status && x.Value == DkSmittestopClaims.StatusValues.Positive);
             automocker.VerifyAll();
         }
-
+        
         [Test]
-        public async Task GetProfileDataAsync_GivenPinUser_VerifiesStatusAndAddsRequestedClaim()
+        public async Task GetProfileDataAsync_GivenNationalYoungerThanThreshold_GetsBlockedAndNoUploadClaim()
         {
             var automocker = new AutoMocker();
 
-            var verificationLimit = new Mock<IVerificationLimit>();
-
             automocker
-                .Setup<IMediator, Task<VerificationResult>>(x => x.Send(It.IsAny<VerifyPinUser.Command>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new VerificationResult(new PositiveTestResult(), new VerificationRecord[0], verificationLimit.Object));
+                .SetupOptions(new AnonymousTokensConfig
+                {
+                    Enabled = true,
+                    EnabledClientFlags = new[] { "some-flag", "some-other-flag" }
+                })
+                .SetupOptions(DefaultVerificationLimitConfig);
+
+            var context = new ProfileDataRequestContext
+            {
+                Subject = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(InternalClaims.NationalIdentifier, "01012068359"),
+                    new Claim(InternalClaims.Pseudonym, "pseudo-1")
+                })),
+                RequestedClaimTypes = new[]
+                {
+                    JwtClaimTypes.Role, 
+                    DkSmittestopClaims.Covid19Blocked,
+                    DkSmittestopClaims.Covid19Status,
+                    DkSmittestopClaims.Covid19LimitCount,
+                    DkSmittestopClaims.Covid19LimitDuration,
+                    
+                }
+            };
+
+            var target = automocker.CreateInstance<ProfileService>();
+
+            await target.GetProfileDataAsync(context);
+
+            context.IssuedClaims.Should().NotContain(x => x.Type == JwtClaimTypes.Role && x.Value == VerificationRoles.UploadApproved);
+            context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19Blocked && x.Value == "true");
+            context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19LimitCount);
+            context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19LimitDuration);
+        }
+        
+        //01012068359
+
+        [Test]
+        public async Task GetProfileDataAsync_GivenPinUser_GetsRejected()
+        {
+            var automocker = new AutoMocker();
             automocker
                 .SetupOptions(new AnonymousTokensConfig
                 {
                     Enabled = true,
                     EnabledClientFlags = new []{"some-flag", "some-other-flag"}
-                });
+                })
+                .SetupOptions(DefaultVerificationLimitConfig);
 
             var context = new ProfileDataRequestContext
             {
@@ -96,14 +136,21 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
                     new Claim(InternalClaims.PinVerified, "true"),
                     new Claim(InternalClaims.Pseudonym, "pseudo-1")
                 })),
-                RequestedClaimTypes = new[] { DkSmittestopClaims.Covid19Status }
+                RequestedClaimTypes = new[]
+                {
+                    DkSmittestopClaims.Covid19Status,
+                    DkSmittestopClaims.Covid19Blocked,
+                    JwtClaimTypes.Role
+                }
             };
 
             var target = automocker.CreateInstance<ProfileService>();
 
             await target.GetProfileDataAsync(context);
 
-            context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19Status && x.Value == DkSmittestopClaims.StatusValues.Positive);
+            context.IssuedClaims.Should().NotContain(x => x.Type == DkSmittestopClaims.Covid19Status && x.Value == DkSmittestopClaims.StatusValues.Positive);
+            context.IssuedClaims.Should().NotContain(x => x.Type == JwtClaimTypes.Role && x.Value == VerificationRoles.UploadApproved);
+            context.IssuedClaims.Should().Contain(x => x.Type == DkSmittestopClaims.Covid19Blocked && x.Value == "true");
             automocker.VerifyAll();
         }
 
@@ -117,13 +164,14 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
                 {
                     Enabled = true,
                     EnabledClientFlags = new[] { "some-flag", "some-other-flag" }
-                });
+                })
+                 .SetupOptions(DefaultVerificationLimitConfig);;
 
             var context = new ProfileDataRequestContext
             {
                 Subject = new ClaimsPrincipal(new ClaimsIdentity(new[]
                 {
-                    new Claim(InternalClaims.NationalIdentifier, "01019098765"),
+                    new Claim(InternalClaims.NationalIdentifier, "08089409382"),
                     new Claim(InternalClaims.Pseudonym, "pseudo-1")
                 })),
                 RequestedClaimTypes = new[] { VerificationClaims.AnonymousToken }
@@ -148,7 +196,8 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
                 {
                     Enabled = false,
                     EnabledClientFlags = new [] {"should-not-be-returned"}
-                });
+                })
+                .SetupOptions(DefaultVerificationLimitConfig);
 
             var context = new ProfileDataRequestContext
             {
@@ -166,5 +215,12 @@ namespace Fhi.Smittestopp.Verification.Tests.Server.Account
 
             context.IssuedClaims.Should().NotContain(x => x.Type == VerificationClaims.AnonymousToken);
         }
+        
+        private static VerificationLimitConfig DefaultVerificationLimitConfig = new VerificationLimitConfig()
+        {
+            MaxLimitDuration = new TimeSpan(0,24,0),
+            MaxVerificationsAllowed = 3,
+            MinimumAgeInYears = 16
+        };
     }
 }

--- a/test-client/src/app/app.component.html
+++ b/test-client/src/app/app.component.html
@@ -22,6 +22,11 @@
 
   <h2>Access token</h2>
   <p>{{accessToken}}</p>
+  <div *ngIf="accessToken">
+    <i>Access token payload:</i>
+    <pre>{{decodeAccessTokenPayload(accessToken) | json}}</pre>
+
+  </div>
 
   <h2>Granted scopes</h2>
   <pre>{{grantedScopes|json}}</pre>

--- a/test-client/src/app/app.component.ts
+++ b/test-client/src/app/app.component.ts
@@ -39,11 +39,11 @@ export class AppComponent {
   }
 
   initDefaultMode() {
-    this.initOauth('openid verification-info upload-api', this.forceLoginPrompt);
+    this.initOauth('openid verification-info upload-api no-msis', this.forceLoginPrompt);
   }
 
   initDkCompatibleMode() {
-    this.initOauth('openid smittestop', this.forceLoginPrompt);
+    this.initOauth('openid smittestop no-msis', this.forceLoginPrompt);
   }
 
   startLogin() {
@@ -76,7 +76,7 @@ export class AppComponent {
     var tokenRequest = {
       maskedPoint: "BEHW+VUrA9n68aB5tz89ZY8Ah5xdPOs7SaQ1Xe+mxw0oDihUScGbo/4lHm0l120UwVTUN6sh1CwG9s7tVIJ2saw="
     };
-    
+
     try {
       var response = await this.http.post(
         environment.authIssuer + "/api/anonymoustokens",
@@ -87,7 +87,7 @@ export class AppComponent {
           }
         })
       .toPromise();
-  
+
       this.anonymousTokenResponse = response;
       return this.anonymousTokenResponse;
     } catch (e) {
@@ -112,5 +112,5 @@ export class AppComponent {
       }
     });
   }
-  
+
 }

--- a/test-client/src/app/app.component.ts
+++ b/test-client/src/app/app.component.ts
@@ -39,11 +39,17 @@ export class AppComponent {
   }
 
   initDefaultMode() {
-    this.initOauth('openid verification-info upload-api no-msis', this.forceLoginPrompt);
+    // Uncomment the following 2 lines to verify using the 'no-msis' scope
+    // this.initOauth('openid verification-info upload-api no-msis', this.forceLoginPrompt);
+    // return;
+    this.initOauth('openid verification-info upload-api', this.forceLoginPrompt);
   }
 
   initDkCompatibleMode() {
-    this.initOauth('openid smittestop no-msis', this.forceLoginPrompt);
+    // Uncomment the following lines 2 to verify using the 'no-msis' scope
+    // this.initOauth('openid smittestop no-msis', this.forceLoginPrompt);
+    // return;
+    this.initOauth('openid smittestop', this.forceLoginPrompt);
   }
 
   startLogin() {
@@ -113,4 +119,7 @@ export class AppComponent {
     });
   }
 
+  decodeAccessTokenPayload(accessToken: string) {
+    return JSON.parse(atob(accessToken.split('.')[1]))
+  }
 }

--- a/test-client/src/environments/environment.localhttp.ts
+++ b/test-client/src/environments/environment.localhttp.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  authIssuer: 'http://localhost:5001',
+  authIssuer: 'https://localhost:5001',
   clientId: 'test-spa-client'
 };


### PR DESCRIPTION
This pull request solves the following:
A user must be able to generate and upload an anonymous token regardless if the user has a positive MSIS test result or not.
A user must be able to request that the MSIS database lookup is skipped in the verification process.


This implies that all generated tokens should get the "role":"upload-approved" claim - excluding only those who has reached the verification threshold (number of verifications / time passed)

This directly impacts the verification limit structure - each token generation that results in the "role":"upload-approved" claim being set must count towards a users verification limit.
We must also check whether a person is at least 16 years old here in the Verification solution - this check was priorly done in MSIS.


